### PR TITLE
Bump tmd versions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,8 +3,8 @@
          cljplot/cljplot            {:mvn/version "0.0.2a-SNAPSHOT"}
          mastodonc/kixi.large       {:git/url "https://github.com/MastodonC/kixi.large"
                                      :sha     "06b7827cef89ef6324582cf767339b3812a01f43"}
-         techascent/tech.ml.dataset {:mvn/version "6.00-beta-16"} #_{:mvn/version "5.20"}
-         scicloj/tablecloth         {:mvn/version "6.00-beta-16" :exclusions [techascent/tech.ml.dataset]}}
+         techascent/tech.ml.dataset {:mvn/version "6.005"}
+         scicloj/tablecloth         {:mvn/version "6.002" :exclusions [techascent/tech.ml.dataset]}}
  :aliases
  {:test    {:extra-paths ["test"]
             :extra-deps  {org.clojure/test.check {:mvn/version "1.1.0"}}}


### PR DESCRIPTION
tmd: https://clojars.org/techascent/tech.ml.dataset latest 6.005
tc: https://clojars.org/scicloj/tablecloth latest 6.002 but pointing at tmd 6.002