### PR TITLE
Make legend font size more responsive to the amount of data

### DIFF
--- a/src/kixi/plot.clj
+++ b/src/kixi/plot.clj
@@ -95,7 +95,7 @@
          (fn [c]
            (-> c
                (assoc-in [:legend :font] "Open Sans Bold")
-               (assoc-in [:legend :font-size] (or legend-font-size 24)))))
+               (assoc-in [:legend :font-size] (or legend-font-size (if (< (count legend-spec) 22) 24 16)))))) ;; 22 Items fit in the legend at 24pt
   (let [size (or size {:width 1539 :height 1037 :background colors/white}) ;; 1539x1037 is almost exactly the right size to go into the slide
         title-format (or (::format title) {:font-size 36 :font "Open Sans Bold" :font-style :bold :margin 36})]
     (merge chart-spec


### PR DESCRIPTION
22 items is the most we can fit at 24 point. If we go over that then going down to 16pts is OK as the chart will be a bit busy anyway and you should be looking at breakdowns rather than the overall. The overall is still useful for comparisons though.